### PR TITLE
Add centralized issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report---.md
+++ b/.github/ISSUE_TEMPLATE/bug-report---.md
@@ -1,0 +1,31 @@
+---
+name: "Bug report \U0001F41B"
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+[NOTE]: # ( ^^ Provide a general summary of the issue in the title above. ^^ )
+
+**Description**
+[NOTE]: # ( Describe the problem you're encountering. )
+[TIP]:  # ( Do NOT share sensitive information, whether personal, proprietary, or otherwise! )
+
+**Expected Behavior**
+[NOTE]: # ( Tell us what you expected to happen. )
+
+**[Troubleshooting](https://discuss.newrelic.com/t/troubleshooting-frameworks/108787) or [NR Diag](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics) results**
+[NOTE]: # ( Provide any other relevant log data. )
+[TIP]:  # ( Scrub logs and diagnostic information for sensitive information )
+
+**Steps to Reproduce**
+[NOTE]: # ( Please be as specific as possible. )
+[TIP]:  # ( Link a sample application that demonstrates the issue. )
+
+**Your Environment**
+[TIP]:  # ( Include as many relevant details about your environment as possible including the running version of New Relic software and any relevant configurations. )
+
+**Additional context**
+[TIP]:  # ( Add any other context about the problem here. For example, relevant community posts or support tickets. )

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting
+    about: checkout the README for troubleshooting directions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+priority: '' 
+---
+
+### Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Feature Description
+A clear and concise description of the feature you want or need.
+
+### Describe Alternatives
+A clear and concise description of any alternative solutions or features you've considered. Are there examples you could link us to?
+
+### Additional context
+Add any other context here.
+
+### Priority
+Please help us better understand this feature request by choosing a priority from the following options: 
+[Nice to Have, Really Want, Must Have, Blocker] 

--- a/.github/ISSUE_TEMPLATE/troubleshooting.md
+++ b/.github/ISSUE_TEMPLATE/troubleshooting.md
@@ -1,0 +1,6 @@
+<!-- ⚠️⚠️STOP⚠️⚠️ -- PLEASE READ! -->
+
+We use GitHub to track feature requests and bug reports. Please **do not** submit issues for questions about how to configure, use features, troubleshoot, or best practices for using New Relic software.
+
+See the README.md troubleshooting section in this repository for more details on self-service troubleshooting tooling, links to our comprehenive documentation, and how to get further support.
+


### PR DESCRIPTION
Product management has requested that we add standardized issue templates to each of our repositories. Rather than add issue templates to every repository in the `newrelic` org, it would be great to have these templates centralized! After merging this PR, every repository that doesn't have issue templates defined will use these default templates.

Note: repos in the `newrelic` org with a `.github/ISSUE_TEMPLATE` folder in the repository will override these default templates.

See the [github documentation](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) for details.