### PR TITLE
feat: Update community plus and NR1 catalog ruleset, add CI smoke test for rulesets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Run Repolinter Action
+        id: repolinter
         continue-on-error: true
         uses: newrelic/repolinter-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - repolinter-rulesets/community-plus.json
+          - repolinter-rulesets/new-relic-one-catalog-project.json
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      
+      - name: Run Repolinter Action
+        continue-on-error: true
+        uses: newrelic/repolinter-action@v1
+        with:
+          config_file: ${{ matrix.config }}
+
+      - name: Check Repolinter Action Result
+        env:
+          DID_ERROR: ${{ steps.repolinter.outputs.errored }}
+        shell: bash
+        run: '[ "$DID_ERROR" = "false" ]'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # .github
-Standard policy and procedure across the New Relic GitHub organization
+
+Standard policy and procedure across the New Relic GitHub organization.
+
+## Rulesets
+
+The following is a high-level overview of the rulesets being enforced by [repolinter-action](https://github.com/newrelic/repolinter-action).
+
+### NR1 Catalog
+
+ * `license-file-exists` - Checks that a `LICENSE` or `COPYING` file exists. Does not check for a particular variant of license, it is up to the repository maintainer to ensure the license is correct.
+ * `readme-file-exists` - Checks that a `README.md` file exists.
+ * `readme-starts-with-nr1-catalog-header` - Checks that the [NR1 Catalog header](https://github.com/newrelic/opensource-website/wiki/Open-Source-Category-Snippets#category-new-relic-one-catalog-project) is present in the first line of `README.md`. This header must be the most recent version, and may need to be updated:
+```md
+[![New Relic One Catalog Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/New_Relic_One_Catalog_Project.png)](https://opensource.newrelic.com/oss-category/#new-relic-one-catalog-project)
+```
+ * `readme-contains-security-section` - Checks that a `## Security` markdown header exists in `README.md`. This check is designed to determine if a security section is present.
+ * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy`.
+ * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
+ * `third-party-notices-file-exists` - Checks that a `THIRD_PARTY_NOTICES.md` file exists, does not verify that the content is correct. A `THIRD_PARTY_NOTICES.md` file may any have of the following alternate filenames:
+   * `THIRD_PARTY_NOTICES*`
+   * `THIRD-PARTY-NOTICES*`
+   * `THIRDPARTYNOTICES*`
+ * `nr1-catalog-config-file-exists` - Checks that a `catalog/config.json` file exists for the NR1 catalog metadata.
+ * `nr1-catalog-config-file-exists` - Checks that a `catalog/screenshots` directory exists for the NR1 catalog metadata.
+ * `nr1-catalog-screenshots-directory-exists` - Checks that a `catalog/screenshots` directory exists for the NR1 catalog metadata.
+ * `nr1-catalog-documentation-file-exists` - Checks that a `catalog/documentation.md` file exists for the NR1 catalog metadata.
+ * `package-scripts-present` - Checks that `eslint-fix` and `eslint-check` scripts are present in the `package.json`. These scripts may contain any commands.
+
+### Community Plus
+
+ * `license-file-exists` - Checks that a `LICENSE` or `COPYING` file exists. Does not check for a particular variant of license, it is up to the repository maintainer to ensure the license is correct.
+ * `readme-file-exists` - Checks that a `README.md` file exists.
+ * `readme-starts-with-community-plus-header` - Checks that the [Community Plus header](https://github.com/newrelic/opensource-website/wiki/Open-Source-Category-Snippets#category-community-plus) is present in the first line of `README.md`. This header must be the most recent version, and may need to be updated:
+```md
+[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+```
+ * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy`.
+ * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
+ * `third-party-notices-file-exists` - Checks that a `THIRD_PARTY_NOTICES.md` file exists, does not verify that the content is correct. A `THIRD_PARTY_NOTICES.md` file may any have of the following alternate filenames:
+   * `THIRD_PARTY_NOTICES*`
+   * `THIRD-PARTY-NOTICES*`
+   * `THIRDPARTYNOTICES*`

--- a/repolinter-rulesets/community-plus.json
+++ b/repolinter-rulesets/community-plus.json
@@ -67,19 +67,19 @@
             "policyInfo": "The README of a community plus project should have a community plus header at the start of the README",
             "policyUrl": "https://opensource.newrelic.com/oss-category/"
         },
-        "readme-contains-security-section": {
+        "readme-contains-link-to-security-policy": {
             "level": "error",
             "rule": {
                 "type": "file-contents",
                 "options": {
                     "globsAll": ["README*"],
                     "fail-on-non-exist": true,
-                    "flags": "mi",
-                    "content": "^#+\\s*security[\\w\\s]*$",
-                    "human-readable-content": "a security section"
+                    "flags": "i",
+                    "content": "https:\\/\\/github\\.com\\/newrelic\\/[^\\/]+\\/security\\/policy",
+                    "human-readable-content": "a link to the security policy for this repository"
                 }
             },
-            "policyInfo": "New Relic recommends referencing our open source security policies in the README",
+            "policyInfo": "New Relic recommends referencing the open source security policy (found under the \"Security\" tab of the repository) in the README. For an example of this, please see the [Open By Default repository](https://github.com/newrelic/open-by-default#contribute)",
             "policyUrl": "https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code"
         },
         "readme-contains-discuss-topic": {
@@ -111,21 +111,6 @@
                 }
             },
             "policyInfo": "A THIRD_PARTY_NOTICES.md file must be present to grant attribution to all dependencies being used by this project. For JavaScript projects, you can generate this file using the [oss-cli](https://github.com/newrelic/newrelic-oss-cli)",
-            "policyUrl": "https://docs.google.com/document/d/1y644Pwi82kasNP5VPVjDV8rsmkBKclQVHFkz8pwRUtE/view"
-        },
-        "github-actions-workflow-file-exists": {
-            "level": "error",
-            "rule": {
-                "type": "file-existence",
-                "options": {
-                    "globsAny": [
-                        ".github/workflows/*.yml",
-                        ".github/workflows/*.yaml"
-                    ],
-                    "nocase": true
-                }
-            },
-            "policyInfo": "Any Community Plus project must integrate with GitHub actions",
             "policyUrl": "https://docs.google.com/document/d/1y644Pwi82kasNP5VPVjDV8rsmkBKclQVHFkz8pwRUtE/view"
         }
     },

--- a/repolinter-rulesets/community-plus.json
+++ b/repolinter-rulesets/community-plus.json
@@ -42,7 +42,7 @@
             "policyInfo": "New Relic requires a README file in all projects. This README should give a general overview of the project, and should point to additional resources (security, contributing, etc.) where developers and users can learn further",
             "policyUrl": "https://github.com/newrelic/open-source-tools/tree/master/javascript/oss-template"
         },
-        "readme-starts-with-community-header": {
+        "readme-starts-with-community-plus-header": {
             "level": "error",
             "rule": {
                 "type": "file-starts-with",

--- a/repolinter-rulesets/new-relic-one-catalog-project.json
+++ b/repolinter-rulesets/new-relic-one-catalog-project.json
@@ -82,6 +82,21 @@
             "policyInfo": "New Relic recommends referencing our open source security policies in the README, found at https://github.com/newrelic/.github/blob/main/SECURITY.md",
             "policyUrl": "https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code"
         },
+        "readme-contains-link-to-security-policy": {
+            "level": "error",
+            "rule": {
+                "type": "file-contents",
+                "options": {
+                    "globsAll": ["README*"],
+                    "fail-on-non-exist": true,
+                    "flags": "i",
+                    "content": "https:\\/\\/github\\.com\\/newrelic\\/[^\\/]+\\/security\\/policy",
+                    "human-readable-content": "a link to the security policy for this repository"
+                }
+            },
+            "policyInfo": "New Relic recommends referencing the open source security policy (found under the \"Security\" tab of the repository) in the README. For an example of this, please see the [Open By Default repository](https://github.com/newrelic/open-by-default#contribute)",
+            "policyUrl": "https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code"
+        },
         "readme-contains-discuss-topic": {
             "level": "error",
             "rule": {


### PR DESCRIPTION
This PR updates the community plus ruleset to reflect changes suggested by @elucus:
 * The GitHub actions check has been removed to account for teams still using other CI providers
 * The security section check has been refactored into a security policy link check to better align with the [Open By Default](https://github.com/newrelic/open-by-default) template.

In addition to these changes, the NR1 catalog ruleset was updated to include a security policy link check, additional ruleset description was added to the README, and a CI check was added to verify that all rulesets do not cause repolinter-action to throw an error.