### PR TITLE
fix: update security link policy to check for relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+
 # .github
 
 Standard policy and procedure across the New Relic GitHub organization.
@@ -15,7 +17,7 @@ The following is a high-level overview of the rulesets being enforced by [repoli
 [![New Relic One Catalog Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/New_Relic_One_Catalog_Project.png)](https://opensource.newrelic.com/oss-category/#new-relic-one-catalog-project)
 ```
  * `readme-contains-security-section` - Checks that a `## Security` markdown header exists in `README.md`. This check is designed to determine if a security section is present.
- * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy`.
+ * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`.
  * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
  * `third-party-notices-file-exists` - Checks that a `THIRD_PARTY_NOTICES.md` file exists, does not verify that the content is correct. A `THIRD_PARTY_NOTICES.md` file may any have of the following alternate filenames:
    * `THIRD_PARTY_NOTICES*`
@@ -35,7 +37,7 @@ The following is a high-level overview of the rulesets being enforced by [repoli
 ```md
 [![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 ```
- * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy`.
+ * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`.
  * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
  * `third-party-notices-file-exists` - Checks that a `THIRD_PARTY_NOTICES.md` file exists, does not verify that the content is correct. A `THIRD_PARTY_NOTICES.md` file may any have of the following alternate filenames:
    * `THIRD_PARTY_NOTICES*`

--- a/repolinter-rulesets/community-plus.yml
+++ b/repolinter-rulesets/community-plus.yml
@@ -77,11 +77,11 @@ rules:
         - README*
         fail-on-non-exist: true
         flags: i
-        content: https:\/\/github\.com\/newrelic\/[^\/]+\/security\/policy
+        content: (?:(?:https:\/\/github\.com\/newrelic\/[^\/]+)|(?:\.\.\/\.\.))\/security\/policy
         human-readable-content: a link to the security policy for this repository
     policyInfo: >-
       New Relic recommends putting a link to the open source security policy for your project
-      (`https://github.com/newrelic/<repo-name>/security/policy`)
+      (`https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`)
       in the README. For an example of this, please see the "a note about vulnerabilities"
       section of the [Open By Default repository](https://github.com/newrelic/open-by-default#contribute)
     policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code

--- a/repolinter-rulesets/new-relic-one-catalog-project.json
+++ b/repolinter-rulesets/new-relic-one-catalog-project.json
@@ -90,11 +90,11 @@
                     "globsAll": ["README*"],
                     "fail-on-non-exist": true,
                     "flags": "i",
-                    "content": "https:\\/\\/github\\.com\\/newrelic\\/[^\\/]+\\/security\\/policy",
+                    "content": "(?:(?:https:\\/\\/github\\.com\\/newrelic\\/[^\\/]+)|(?:\\.\\.\\/\\.\\.))\\/security\\/policy",
                     "human-readable-content": "a link to the security policy for this repository"
                 }
             },
-            "policyInfo": "New Relic recommends referencing the open source security policy (`https://github.com/newrelic/<repo-name>/security/policy`) in a Security section in the README. For an example of this, please see the [NR1 Catalog Template](https://github.com/newrelic/template-nerdpack#security)",
+            "policyInfo": "New Relic recommends referencing the open source security policy (`https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`) in a Security section in the README. For an example of this, please see the [NR1 Catalog Template](https://github.com/newrelic/template-nerdpack#security)",
             "policyUrl": "https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code"
         },
         "readme-contains-discuss-topic": {


### PR DESCRIPTION
This PR adds support for relative security policy URLs (`../../security/policy`).