### PR TITLE
feat: add code of conduct rule to nr1 catalog and community plus rulesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The following is a high-level overview of the rulesets being enforced by [repoli
  * `readme-contains-security-section` - Checks that a `## Security` markdown header exists in `README.md`. This check is designed to determine if a security section is present.
  * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`.
  * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
+ * `code-of-conduct-file-does-not-exist` - Checks that a code of conduct file is not present in the repository. This file can match any of the following patterns:
+   * `CODE-OF-CONDUCT*`
+   * `CODE_OF_CONDUCT*`
+   * `CODEOFCONDUCT*`
  * `third-party-notices-file-exists` - Checks that a `THIRD_PARTY_NOTICES.md` file exists, does not verify that the content is correct. A `THIRD_PARTY_NOTICES.md` file may any have of the following alternate filenames:
    * `THIRD_PARTY_NOTICES*`
    * `THIRD-PARTY-NOTICES*`
@@ -39,6 +43,10 @@ The following is a high-level overview of the rulesets being enforced by [repoli
 ```
  * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`.
  * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
+ * `code-of-conduct-file-does-not-exist` - Checks that a code of conduct file is not present in the repository. This file can match any of the following patterns:
+   * `CODE-OF-CONDUCT*`
+   * `CODE_OF_CONDUCT*`
+   * `CODEOFCONDUCT*`
  * `third-party-notices-file-exists` - Checks that a `THIRD_PARTY_NOTICES.md` file exists, does not verify that the content is correct. A `THIRD_PARTY_NOTICES.md` file may any have of the following alternate filenames:
    * `THIRD_PARTY_NOTICES*`
    * `THIRD-PARTY-NOTICES*`

--- a/repolinter-rulesets/community-plus.yml
+++ b/repolinter-rulesets/community-plus.yml
@@ -100,6 +100,24 @@ rules:
       New Relic recommends directly linking the your appropriate discuss.newrelic.com
       topic in the README, allowing developer an alternate method of getting support
     policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code
+  code-of-conduct-file-does-not-exist:
+    level: error
+    rule:
+      type: file-not-exists
+      options:
+        globsAll:
+        - CODE_OF_CONDUCT*
+        - CODE-OF-CONDUCT*
+        - CODEOFCODUCT
+        nocase: true
+    fix:
+      type: file-remove
+      options: {}
+    policyInfo: >-
+      New Relic has moved the `CODE_OF_CONDUCT` file to a [centralized location](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)
+      where it is referenced automatically by every repository in the New Relic organization. Because of this change, any other `CODE_OF_CONDUCT` file
+      in a repository is now redundant and should be removed
+    policyUrl: https://docs.google.com/document/d/1vML4aY_czsY0URu2yiP3xLAKYufNrKsc7o4kjuegpDw/edit
   third-party-notices-file-exists:
     level: warning
     rule:
@@ -119,7 +137,7 @@ rules:
       be pre-installed in the classpath, outside the project binary and therefore
       outside the scope of the `THIRD_PARTY_NOTICES`). Please
       review your project's dependencies and create a THIRD_PARTY_NOTICES.md file if
-      necessary. For JavaScript projects, you can generate this file using the 
+      necessary. For JavaScript projects, you can generate this file using the
       [oss-cli](https://github.com/newrelic/newrelic-oss-cli)
     policyUrl: https://docs.google.com/document/d/1y644Pwi82kasNP5VPVjDV8rsmkBKclQVHFkz8pwRUtE/view
 formatOptions:

--- a/repolinter-rulesets/new-relic-one-catalog-project.json
+++ b/repolinter-rulesets/new-relic-one-catalog-project.json
@@ -128,6 +128,26 @@
             "policyInfo": "A THIRD_PARTY_NOTICES.md file must be present to grant attribution to all dependencies being used by this project. For JavaScript projects, you can generate this file using the [oss-cli](https://github.com/newrelic/newrelic-oss-cli)",
             "policyUrl": "https://docs.google.com/document/d/1y644Pwi82kasNP5VPVjDV8rsmkBKclQVHFkz8pwRUtE/view"
         },
+        "code-of-conduct-file-does-not-exist": {
+            "level": "error",
+            "rule": {
+               "type": "file-not-exists",
+               "options": {
+                  "globsAll": [
+                     "CODE_OF_CONDUCT*",
+                     "CODE-OF-CONDUCT*",
+                     "CODEOFCODUCT"
+                  ],
+                  "nocase": true
+               }
+            },
+            "fix": {
+               "type": "file-remove",
+               "options": {}
+            },
+            "policyInfo": "New Relic has moved the `CODE_OF_CONDUCT` file to a [centralized location](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md) where it is referenced automatically by every repository in the New Relic organization. Because of this change, any other `CODE_OF_CONDUCT` file in a repository is now redundant and should be removed",
+            "policyUrl": "https://docs.google.com/document/d/1vML4aY_czsY0URu2yiP3xLAKYufNrKsc7o4kjuegpDw/edit"
+        },
         "github-actions-workflow-file-exists": {
             "level": "error",
             "rule": {


### PR DESCRIPTION
This PR rolls out a policy change to centralize the code of conduct in this repository. The added rule, `code-of-conduct-file-does-not-exist`, checks that a code of conduct file is present and suggests it be removed if so.