### PR TITLE
 fix: update community plus header check to support RST

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,18 @@ The following is a high-level overview of the rulesets being enforced by [repoli
 
  * `license-file-exists` - Checks that a `LICENSE` or `COPYING` file exists. Does not check for a particular variant of license, it is up to the repository maintainer to ensure the license is correct.
  * `readme-file-exists` - Checks that a `README.md` file exists.
- * `readme-starts-with-community-plus-header` - Checks that the [Community Plus header](https://github.com/newrelic/opensource-website/wiki/Open-Source-Category-Snippets#category-community-plus) is present in the first line of `README.md`. This header must be the most recent version, and may need to be updated:
+ * `readme-starts-with-community-plus-header` - Checks that the [Community Plus header](https://github.com/newrelic/opensource-website/wiki/Open-Source-Category-Snippets#category-community-plus) is present in the first line of the `README`. To allow compatibility with both Markdown and reStructured text, this rule only checks the first 5 lines of the `README` for the presence of the image link (`https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png`) and the opensource link (`https://opensource.newrelic.com/oss-category/#community-plus`). This header must be the most recent version to pass, and may need to be updated to one of the following:
+
+Markdown:
 ```md
 [![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+```
+reStructured Text:
+```rst
+|header|
+
+.. |header| image:: https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png
+    :target: https://opensource.newrelic.com/oss-category/#community-plus
 ```
  * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`.
  * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
@@ -43,3 +52,6 @@ The following is a high-level overview of the rulesets being enforced by [repoli
    * `THIRD_PARTY_NOTICES*`
    * `THIRD-PARTY-NOTICES*`
    * `THIRDPARTYNOTICES*`
+
+## Notes for Ruleset Creation
+* If the rule intends to check the contents of `README.md`, ensure that a [`README.rst`](https://github.com/DevDungeon/reStructuredText-Documentation-Reference) is also supported, as some projects prefer reStructured text to Markdown (ex. [newrelic-python-agent](https://github.com/newrelic/newrelic-python-agent)).

--- a/repolinter-rulesets/community-plus.yml
+++ b/repolinter-rulesets/community-plus.yml
@@ -50,9 +50,10 @@ rules:
         globsAll:
         - README*
         nocase: true
-        lineCount: 1
+        lineCount: 5
         patterns:
-        - "\\[\\s*\\!\\[[a-z0-9\\s]+\\]\\(\\s*https:\\/\\/github\\.com\\/newrelic\\/opensource-website\\/raw\\/master\\/src\\/images\\/categories\\/Community_Plus\\.png\\s*\\)\\s*\\]\\(\\s*https:\\/\\/opensource\\.newrelic\\.com\\/oss-category\\/#community-plus\\s*\\)"
+        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/master\/src\/images\/categories\/Community_Plus\.png
+        - https:\/\/opensource\.newrelic\.com\/oss-category\/#community-plus
         human-readable-pattern: Open source Community Plus header (see https://opensource.newrelic.com/oss-category)
         flags: i
         succeed-on-non-existent: false


### PR DESCRIPTION
This PR adds support for reStructured text to the community plus header check, allowing projects such as [newrelic-python-agent](https://github.com/newrelic/newrelic-python-agent) to use this alternate syntax for their README.