### PR TITLE
fix: Update repolinter workflow to checkout config instead of pulling from githubusercontent

### DIFF
--- a/.github/workflows/repolinter-apply.yml
+++ b/.github/workflows/repolinter-apply.yml
@@ -16,18 +16,26 @@ jobs:
         include:
           # Edit here to add other repositories
           - repo: newrelic/newrelic-python-agent
-            config: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-plus.yml
+            config: repolinter-rulesets/community-plus.yml
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
+      - name: Checkout Self
         uses: actions/checkout@v2
         with:
+          path: ./repo
+
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@v2
+        with:
+          path: ./apply
           repository: ${{ matrix.repo }}
           token: ${{ secrets.REPOLINTER_TOKEN }}
       
       - name: Run Repolinter
         uses: newrelic/repolinter-action@v1
         with:
+          directory: ${{ github.workspace }}/apply
+          config_file: ${{ github.workspace }}/repo/${{ matrix.config }}
           config_url: ${{ matrix.config }}
           output_type: issue
           username: nr-opensource-bot

--- a/repolinter-rulesets/community-plus.yml
+++ b/repolinter-rulesets/community-plus.yml
@@ -118,7 +118,7 @@ rules:
       New Relic has moved the `CODE_OF_CONDUCT` file to a [centralized location](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)
       where it is referenced automatically by every repository in the New Relic organization. Because of this change, any other `CODE_OF_CONDUCT` file
       in a repository is now redundant and should be removed
-    policyUrl: https://docs.google.com/document/d/1vML4aY_czsY0URu2yiP3xLAKYufNrKsc7o4kjuegpDw/edit
+    policyUrl: https://docs.google.com/document/d/1y644Pwi82kasNP5VPVjDV8rsmkBKclQVHFkz8pwRUtE/view
   third-party-notices-file-exists:
     level: warning
     rule:

--- a/repolinter-rulesets/new-relic-one-catalog-project.json
+++ b/repolinter-rulesets/new-relic-one-catalog-project.json
@@ -146,7 +146,7 @@
                "options": {}
             },
             "policyInfo": "New Relic has moved the `CODE_OF_CONDUCT` file to a [centralized location](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md) where it is referenced automatically by every repository in the New Relic organization. Because of this change, any other `CODE_OF_CONDUCT` file in a repository is now redundant and should be removed",
-            "policyUrl": "https://docs.google.com/document/d/1vML4aY_czsY0URu2yiP3xLAKYufNrKsc7o4kjuegpDw/edit"
+            "policyUrl": "https://docs.google.com/document/d/1y644Pwi82kasNP5VPVjDV8rsmkBKclQVHFkz8pwRUtE/view"
         },
         "github-actions-workflow-file-exists": {
             "level": "error",


### PR DESCRIPTION
This PR addresses an issue seen in [this `Apply Repolinter` workflow run](https://github.com/newrelic/.github/actions/runs/248280255) where raw.githubusercontent.com does not serve the latest changes until after the repolinter action workflow has pulled the configuration. This desync causes repolinter action to use the configurations from the previous commit instead of the one just pushed, creating unnecessary issue noise. To address this problem, the `Apply Repolinter` workflow has been adjusted to extract configurations using a git checkout, which should always fetch the latest version.

In addition to the above changes, the `code-of-conduct-file-does-not-exist` rule has been fixed to point to the correct policy document.