### PR TITLE
feat: add new-relic-experimental ruleset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
         config:
           - repolinter-rulesets/community-plus.yml
           - repolinter-rulesets/new-relic-one-catalog-project.json
+          - repolinter-rulesets/example-code.yml
+          - repolinter-rulesets/new-relic-experimental.yml
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ reStructured Text:
 ## Notes for Ruleset Creation
 * If the rule intends to check the contents of `README.md`, ensure that a [`README.rst`](https://github.com/DevDungeon/reStructuredText-Documentation-Reference) is also supported, as some projects prefer reStructured text to Markdown (ex. [newrelic-python-agent](https://github.com/newrelic/newrelic-python-agent)).
 * Make sure to double check all the links!
+* Remember to add the ruleset path to the [`test` workflow](./.github/workflows/test.yml).

--- a/README.md
+++ b/README.md
@@ -88,6 +88,33 @@ reStructured Text:
    * `THIRD-PARTY-NOTICES*`
    * `THIRDPARTYNOTICES*`
 
+### [New Relic Experimental](./repolinter-rulesets/new-relic-experimental.yml)
+
+ * `license-file-exists` - Checks that a `LICENSE` or `COPYING` file exists. Does not check for a particular variant of license, it is up to the repository maintainer to ensure the license is correct.
+ * `readme-file-exists` - Checks that a `README.md` file exists.
+ * `readme-starts-with-experimental-header` - Checks that the [Experimental header](https://github.com/newrelic/opensource-website/wiki/Open-Source-Category-Snippets#category-new-relic-experimental) is present in the first line of the `README`. To allow compatibility with both Markdown and reStructured text, this rule only checks the first 5 lines of the `README` for the presence of the image link (`https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png`) and the opensource link (`https://opensource.newrelic.com/oss-category/#new-relic-experimental`). This header must be the most recent version to pass, and may need to be updated to one of the following:
+
+Markdown:
+```md
+[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
+```
+reStructured Text:
+```rst
+|header|
+
+.. |header| image:: https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png
+    :target: https://opensource.newrelic.com/oss-category/#new-relic-experimental
+```
+ * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`.
+ * `code-of-conduct-file-does-not-exist` - Checks that a code of conduct file is not present in the repository. This file can match any of the following patterns:
+   * `CODE-OF-CONDUCT*`
+   * `CODE_OF_CONDUCT*`
+   * `CODEOFCONDUCT*`
+ * `third-party-notices-file-exists` - Checks that a `THIRD_PARTY_NOTICES.md` file exists, does not verify that the content is correct. A `THIRD_PARTY_NOTICES.md` file may any have of the following alternate filenames:
+   * `THIRD_PARTY_NOTICES*`
+   * `THIRD-PARTY-NOTICES*`
+   * `THIRDPARTYNOTICES*`
+
 
 ## Notes for Ruleset Creation
 * If the rule intends to check the contents of `README.md`, ensure that a [`README.rst`](https://github.com/DevDungeon/reStructuredText-Documentation-Reference) is also supported, as some projects prefer reStructured text to Markdown (ex. [newrelic-python-agent](https://github.com/newrelic/newrelic-python-agent)).

--- a/repolinter-rulesets/new-relic-experimental.yml
+++ b/repolinter-rulesets/new-relic-experimental.yml
@@ -1,0 +1,136 @@
+# Schema: https://raw.githubusercontent.com/newrelic-forks/repolinter/master/rulesets/schema.json
+version: 2
+axioms: {}
+rules:
+  license-file-exists:
+    level: error
+    rule:
+      type: file-existence
+      options:
+        globsAny:
+        - LICENSE*
+        - COPYING*
+        nocase: true
+    fix:
+      type: file-create
+      options:
+        file: LICENSE
+        replace: true
+        text:
+          url: https://www.apache.org/licenses/LICENSE-2.0.txt
+    policyInfo: >-
+      New Relic requires that all open source projects have an associated
+      license contained within the project. This license must be permissive (e.g.
+      non-viral or copyleft), and we recommend Apache 2.0 for most use cases
+    policyUrl: https://docs.google.com/document/d/1vML4aY_czsY0URu2yiP3xLAKYufNrKsc7o4kjuegpDw/edit
+  readme-file-exists:
+    level: error
+    rule:
+      type: file-existence
+      options:
+        globsAny:
+        - README*
+        nocase: true
+    fix:
+      type: file-create
+      options:
+        file: README.md
+        text:
+          url: https://raw.githubusercontent.com/newrelic/open-source-tools/master/nerdpacks/oss-template/README.md
+    policyInfo: >-
+      New Relic requires a README file in all projects. This README should
+      give a general overview of the project, and should point to additional resources
+      (security, contributing, etc.) where developers and users can learn further
+    policyUrl: https://github.com/newrelic/open-source-tools/tree/master/nerdpacks/oss-template
+  readme-starts-with-experimental-header:
+    level: error
+    rule:
+      type: file-starts-with
+      options:
+        globsAll:
+        - README*
+        nocase: true
+        lineCount: 5
+        patterns:
+        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/master\/src\/images\/categories\/Experimental\.png
+        - https:\/\/opensource\.newrelic\.com\/oss-category\/#new-relic-experimental
+        human-readable-pattern: Open source experimental header (see https://opensource.newrelic.com/oss-category)
+        flags: i
+        succeed-on-non-existent: false
+    fix:
+      type: file-modify
+      options:
+        text: "[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)"
+        write_mode: prepend
+        newlines:
+          end: 2
+    policyInfo: >-
+      The README of an experimental project should have an experimental
+      header at the start of the README. If you already have an experimental header
+      and this rule is failing, your header may be out of date, and you should
+      update your header with the suggested one below
+    policyUrl: https://opensource.newrelic.com/oss-category/
+  readme-contains-link-to-security-policy:
+    level: error
+    rule:
+      type: file-contents
+      options:
+        globsAll:
+        - README*
+        fail-on-non-exist: true
+        flags: i
+        content: (?:(?:https:\/\/github\.com\/newrelic\/[^\/]+)|(?:\.\.\/\.\.))\/security\/policy
+        human-readable-content: a link to the security policy for this repository
+    policyInfo: >-
+      New Relic recommends putting a link to the open source security policy for your project
+      (`https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`)
+      in the README. For an example of this, please see the "a note about vulnerabilities"
+      section of the [Open By Default repository](https://github.com/newrelic/open-by-default#contribute)
+    policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code
+  code-of-conduct-file-does-not-exist:
+    level: error
+    rule:
+      type: file-not-exists
+      options:
+        globsAll:
+        - CODE_OF_CONDUCT*
+        - CODE-OF-CONDUCT*
+        - CODEOFCODUCT
+        nocase: true
+    fix:
+      type: file-remove
+      options: {}
+    policyInfo: >-
+      New Relic has moved the `CODE_OF_CONDUCT` file to a [centralized location](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)
+      where it is referenced automatically by every repository in the New Relic organization. Because of this change, any other `CODE_OF_CONDUCT` file
+      in a repository is now redundant and should be removed
+    policyUrl: https://docs.google.com/document/d/1y644Pwi82kasNP5VPVjDV8rsmkBKclQVHFkz8pwRUtE/view
+  third-party-notices-file-exists:
+    level: warning
+    rule:
+      type: file-existence
+      options:
+        globsAny:
+        - THIRD_PARTY_NOTICES*
+        - THIRD-PARTY-NOTICES*
+        - THIRDPARTYNOTICES*
+        nocase: true
+    policyInfo: >-
+      A [`THIRD_PARTY_NOTICES.md`](https://github.com/newrelic/opensource-website/blob/develop/THIRD_PARTY_NOTICES.md)
+      file can be present in your repository to grant attribution to all dependencies
+      being used by this project. This document is necessary if you are using
+      third-party source code in your project, with the exception of code referenced outside
+      the project's compiled/bundled binary (ex. some Java projects require modules to
+      be pre-installed in the classpath, outside the project binary and therefore
+      outside the scope of the `THIRD_PARTY_NOTICES`). Please
+      review your project's dependencies and create a THIRD_PARTY_NOTICES.md file if
+      necessary. For JavaScript projects, you can generate this file using the
+      [oss-cli](https://github.com/newrelic/newrelic-oss-cli)
+    policyUrl: https://docs.google.com/document/d/1y644Pwi82kasNP5VPVjDV8rsmkBKclQVHFkz8pwRUtE/view
+formatOptions:
+  disclaimer: >-
+    🤖*This issue was automatically generated by [repolinter-action](https://github.com/newrelic/repolinter-action),
+    developed by the Open Source and Developer Advocacy team at New Relic. This issue
+    will be automatically updated or closed when changes are pushed. If you have any
+    problems with this tool, please feel free to open a GitHub issue or give us a
+    ping in #help-opensource.*


### PR DESCRIPTION
This PR adds a repolinter ruleset for the new-relic-experimental category.