### PR TITLE
Update repolinter-apply.yml to include Python OTel exporter repo

### DIFF
--- a/.github/workflows/repolinter-apply.yml
+++ b/.github/workflows/repolinter-apply.yml
@@ -17,6 +17,8 @@ jobs:
           # Edit here to add other repositories
           - repo: newrelic/newrelic-python-agent
             config: repolinter-rulesets/community-plus.yml
+          - repo: newrelic/opentelemetry-exporter-python
+            config: repolinter-rulesets/community-plus.yml
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Self


### PR DESCRIPTION
Added the newrelic/opentelemetry-exporter-python repo to the list of repos in the repolinter-apply.yml file. 