### PR TITLE
chore: updated dropdown rule regex

### DIFF
--- a/repolinter-rulesets/nr1-lib-deprecations.yml
+++ b/repolinter-rulesets/nr1-lib-deprecations.yml
@@ -13,7 +13,7 @@ rules:
         - "!node_modules/**"
         fail-on-non-exist: false
         flags: gm
-        content: (<(Dropdown)\s[^>]*(label)=*)
+        content: (import {).*(Dropdown).*(} from 'nr1').*(<(Dropdown)\s[^>]*(label)=*)
         human-readable-content: The Dropdown label property is deprecated
     policyInfo: >-
       See the New Relic Developer docs for current API details


### PR DESCRIPTION
This change updates the regex to only flag dropdown components from the nr1 package.