### PR TITLE
Update linter rules to use main instead of master for oss image

### DIFF
--- a/repolinter-rulesets/community-project.yml
+++ b/repolinter-rulesets/community-project.yml
@@ -52,7 +52,7 @@ rules:
         nocase: true
         lineCount: 5
         patterns:
-        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/master\/src\/images\/categories\/Community_Project\.png
+        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Project\.png
         - https:\/\/opensource\.newrelic\.com\/oss-category\/#community-project
         human-readable-pattern: Open source Community header (see https://opensource.newrelic.com/oss-category)
         flags: i
@@ -60,7 +60,7 @@ rules:
     fix:
       type: file-modify
       options:
-        text: "[![Community header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)"
+        text: "[![Community header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)"
         write_mode: prepend
         newlines:
           end: 2


### PR DESCRIPTION
There is no longer a master branch on the open source website repo, we instead use main. additionally, the images on main now have a white background which keeps the text from getting lost in github's dark mode, so we want to be referencing those