### PR TITLE
Update rulesets to use images from main instead of master

### DIFF
--- a/repolinter-rulesets/community-plus.yml
+++ b/repolinter-rulesets/community-plus.yml
@@ -52,7 +52,7 @@ rules:
         nocase: true
         lineCount: 5
         patterns:
-        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/master\/src\/images\/categories\/Community_Plus\.png
+        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Plus\.png
         - https:\/\/opensource\.newrelic\.com\/oss-category\/#community-plus
         human-readable-pattern: Open source Community Plus header (see https://opensource.newrelic.com/oss-category)
         flags: i
@@ -60,7 +60,7 @@ rules:
     fix:
       type: file-modify
       options:
-        text: "[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)"
+        text: "[![Community Plus header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)"
         write_mode: prepend
         newlines:
           end: 2

--- a/repolinter-rulesets/community-project.yml
+++ b/repolinter-rulesets/community-project.yml
@@ -52,7 +52,7 @@ rules:
         nocase: true
         lineCount: 5
         patterns:
-        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/master\/src\/images\/categories\/Community_Project\.png
+        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Project\.png
         - https:\/\/opensource\.newrelic\.com\/oss-category\/#community-project
         human-readable-pattern: Open source Community header (see https://opensource.newrelic.com/oss-category)
         flags: i
@@ -60,7 +60,7 @@ rules:
     fix:
       type: file-modify
       options:
-        text: "[![Community header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)"
+        text: "[![Community header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)"
         write_mode: prepend
         newlines:
           end: 2

--- a/repolinter-rulesets/example-code.yml
+++ b/repolinter-rulesets/example-code.yml
@@ -52,7 +52,7 @@ rules:
         nocase: true
         lineCount: 5
         patterns:
-        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/master\/src\/images\/categories\/Example_Code\.png
+        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Example_Code\.png
         - https:\/\/opensource\.newrelic\.com\/oss-category\/#example-code
         human-readable-pattern: Open source Example Code header (see https://opensource.newrelic.com/oss-category)
         flags: i
@@ -60,7 +60,7 @@ rules:
     fix:
       type: file-modify
       options:
-        text: "[![Example Code header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Example_Code.png)](https://opensource.newrelic.com/oss-category/#example-code)"
+        text: "[![Example Code header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Example_Code.png)](https://opensource.newrelic.com/oss-category/#example-code)"
         write_mode: prepend
         newlines:
           end: 2

--- a/repolinter-rulesets/new-relic-experimental.yml
+++ b/repolinter-rulesets/new-relic-experimental.yml
@@ -52,7 +52,7 @@ rules:
         nocase: true
         lineCount: 5
         patterns:
-        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/master\/src\/images\/categories\/Experimental\.png
+        - https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Experimental\.png
         - https:\/\/opensource\.newrelic\.com\/oss-category\/#new-relic-experimental
         human-readable-pattern: Open source experimental header (see https://opensource.newrelic.com/oss-category)
         flags: i
@@ -60,7 +60,7 @@ rules:
     fix:
       type: file-modify
       options:
-        text: "[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)"
+        text: "[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)"
         write_mode: prepend
         newlines:
           end: 2


### PR DESCRIPTION
This supercedes #30 as it updates all of the rulesets to use `main` instead of `master` in URL regexes for image headers, as the ones on `main` are better than the ones on `master`

Addresses #31 and https://github.com/newrelic/node-newrelic/issues/1394