### PR TITLE
chore: update discuss to forum

### DIFF
--- a/docs/repolinter/policy-overviews.md
+++ b/docs/repolinter/policy-overviews.md
@@ -12,7 +12,7 @@ The following is a high-level overview of the rulesets being enforced by [repoli
 ```
  * `readme-contains-security-section` - Checks that a `## Security` markdown header exists in `README.md`. This check is designed to determine if a security section is present.
  * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`.
- * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
+ * `readme-contains-forum-topic` - Checks that a valid link to `forum.newrelic.com` exists in `README.md`.
  * `code-of-conduct-should-not-exist-here` - Checks that a code of conduct file is not present in the repository. This file can match any of the following patterns:
    * `CODE-OF-CONDUCT*`
    * `CODE_OF_CONDUCT*`
@@ -45,7 +45,7 @@ reStructured Text:
     :target: https://opensource.newrelic.com/oss-category/#community-plus
 ```
  * `readme-contains-link-to-security-policy` - Checks that a link to the security policy is present in `README.md`. The security policy can be found under `https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`.
- * `readme-contains-discuss-topic` - Checks that a valid link to `discuss.newrelic.com` exists in `README.md`.
+ * `readme-contains-forum-topic` - Checks that a valid link to `forum.newrelic.com` exists in `README.md`.
  * `code-of-conduct-should-not-exist-here` - Checks that a code of conduct file is not present in the repository. This file can match any of the following patterns:
    * `CODE-OF-CONDUCT*`
    * `CODE_OF_CONDUCT*`

--- a/repolinter-rulesets/community-plus.yml
+++ b/repolinter-rulesets/community-plus.yml
@@ -8,8 +8,8 @@ rules:
       type: file-existence
       options:
         globsAny:
-        - LICENSE*
-        - COPYING*
+          - LICENSE*
+          - COPYING*
         nocase: true
     fix:
       type: file-create
@@ -29,7 +29,7 @@ rules:
       type: file-existence
       options:
         globsAny:
-        - README*
+          - README*
         nocase: true
     fix:
       type: file-create
@@ -48,12 +48,12 @@ rules:
       type: file-starts-with
       options:
         globsAll:
-        - README*
+          - README*
         nocase: true
         lineCount: 5
         patterns:
-        - '<a href="https:\/\/opensource\.newrelic\.com\/oss-category\/#community-plus"><picture><source media="\(prefers-color-scheme: dark\)" srcset="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/dark\/Community_Plus\.png"><source media="\(prefers-color-scheme: light\)" srcset="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Plus\.png"><img alt="New Relic Open Source community plus project banner\." src="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Plus\.png"><\/picture><\/a>'
-        - https:\/\/opensource\.newrelic\.com\/oss-category\/#community-plus
+          - '<a href="https:\/\/opensource\.newrelic\.com\/oss-category\/#community-plus"><picture><source media="\(prefers-color-scheme: dark\)" srcset="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/dark\/Community_Plus\.png"><source media="\(prefers-color-scheme: light\)" srcset="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Plus\.png"><img alt="New Relic Open Source community plus project banner\." src="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Plus\.png"><\/picture><\/a>'
+          - https:\/\/opensource\.newrelic\.com\/oss-category\/#community-plus
         human-readable-pattern: Open source Community Plus header (see https://opensource.newrelic.com/oss-category)
         flags: i
         succeed-on-non-existent: false
@@ -76,7 +76,7 @@ rules:
       type: file-contents
       options:
         globsAll:
-        - README*
+          - README*
         fail-on-non-existent: true
         flags: i
         content: (?:(?:https:\/\/github\.com\/newrelic\/[^\/]+)|(?:\.\.\/\.\.))\/security\/policy
@@ -87,19 +87,19 @@ rules:
       in the README. For an example of this, please see the "a note about vulnerabilities"
       section of the [Open By Default repository](https://github.com/newrelic/open-by-default#contribute)
     policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code
-  readme-contains-discuss-topic:
+  readme-contains-forum-topic:
     level: error
     rule:
       type: file-contents
       options:
         globsAll:
-        - README*
+          - README*
         fail-on-non-existent: true
         flags: i
-        content: discuss\.newrelic\.com
-        human-readable-content: a link to the appropriate discuss.newrelic.com topic
+        content: forum\.newrelic\.com
+        human-readable-content: a link to the appropriate forum.newrelic.com topic
     policyInfo: >-
-      New Relic recommends directly linking the your appropriate discuss.newrelic.com
+      New Relic recommends directly linking the your appropriate forum.newrelic.com
       topic in the README, allowing developer an alternate method of getting support
     policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code
   code-of-conduct-should-not-exist-here:
@@ -108,9 +108,9 @@ rules:
       type: file-not-exists
       options:
         globsAll:
-        - CODE_OF_CONDUCT*
-        - CODE-OF-CONDUCT*
-        - CODEOFCODUCT
+          - CODE_OF_CONDUCT*
+          - CODE-OF-CONDUCT*
+          - CODEOFCODUCT
         nocase: true
     fix:
       type: file-remove
@@ -127,9 +127,9 @@ rules:
       type: file-existence
       options:
         globsAny:
-        - THIRD_PARTY_NOTICES*
-        - THIRD-PARTY-NOTICES*
-        - THIRDPARTYNOTICES*
+          - THIRD_PARTY_NOTICES*
+          - THIRD-PARTY-NOTICES*
+          - THIRDPARTYNOTICES*
         nocase: true
     policyInfo: >-
       A [`THIRD_PARTY_NOTICES.md`](https://github.com/newrelic/opensource-website/blob/develop/THIRD_PARTY_NOTICES.md)

--- a/repolinter-rulesets/community-project.yml
+++ b/repolinter-rulesets/community-project.yml
@@ -8,8 +8,8 @@ rules:
       type: file-existence
       options:
         globsAny:
-        - LICENSE*
-        - COPYING*
+          - LICENSE*
+          - COPYING*
         nocase: true
     fix:
       type: file-create
@@ -29,7 +29,7 @@ rules:
       type: file-existence
       options:
         globsAny:
-        - README*
+          - README*
         nocase: true
     fix:
       type: file-create
@@ -48,12 +48,12 @@ rules:
       type: file-starts-with
       options:
         globsAll:
-        - README*
+          - README*
         nocase: true
         lineCount: 5
         patterns:
-        - '<a href="https:\/\/opensource\.newrelic\.com\/oss-category\/#community-project"><picture><source media="\(prefers-color-scheme: dark\)" srcset="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/dark\/Community_Project\.png"><source media="\(prefers-color-scheme: light\)" srcset="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Project\.png"><img alt="New Relic Open Source community project banner\." src="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Project\.png"><\/picture><\/a>'
-        - https:\/\/opensource\.newrelic\.com\/oss-category\/#community-project
+          - '<a href="https:\/\/opensource\.newrelic\.com\/oss-category\/#community-project"><picture><source media="\(prefers-color-scheme: dark\)" srcset="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/dark\/Community_Project\.png"><source media="\(prefers-color-scheme: light\)" srcset="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Project\.png"><img alt="New Relic Open Source community project banner\." src="https:\/\/github\.com\/newrelic\/opensource-website\/raw\/main\/src\/images\/categories\/Community_Project\.png"><\/picture><\/a>'
+          - https:\/\/opensource\.newrelic\.com\/oss-category\/#community-project
         human-readable-pattern: Open source Community header (see https://opensource.newrelic.com/oss-category)
         flags: i
         succeed-on-non-existent: false
@@ -76,7 +76,7 @@ rules:
       type: file-contents
       options:
         globsAll:
-        - README*
+          - README*
         fail-on-non-existent: true
         flags: i
         content: (?:(?:https:\/\/github\.com\/newrelic\/[^\/]+)|(?:\.\.\/\.\.))\/security\/policy
@@ -87,19 +87,19 @@ rules:
       in the README. For an example of this, please see the "a note about vulnerabilities"
       section of the [Open By Default repository](https://github.com/newrelic/open-by-default#contribute)
     policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code
-  readme-contains-discuss-topic:
+  readme-contains-forum-topic:
     level: error
     rule:
       type: file-contents
       options:
         globsAll:
-        - README*
+          - README*
         fail-on-non-existent: true
         flags: i
-        content: discuss\.newrelic\.com
-        human-readable-content: a link to the appropriate discuss.newrelic.com topic
+        content: forum\.newrelic\.com
+        human-readable-content: a link to the appropriate forum.newrelic.com topic
     policyInfo: >-
-      New Relic recommends directly linking the your appropriate discuss.newrelic.com
+      New Relic recommends directly linking the your appropriate forum.newrelic.com
       topic in the README, allowing developer an alternate method of getting support
     policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code
   code-of-conduct-should-not-exist-here:
@@ -108,9 +108,9 @@ rules:
       type: file-not-exists
       options:
         globsAll:
-        - CODE_OF_CONDUCT*
-        - CODE-OF-CONDUCT*
-        - CODEOFCODUCT
+          - CODE_OF_CONDUCT*
+          - CODE-OF-CONDUCT*
+          - CODEOFCODUCT
         nocase: true
     fix:
       type: file-remove
@@ -127,9 +127,9 @@ rules:
       type: file-existence
       options:
         globsAny:
-        - THIRD_PARTY_NOTICES*
-        - THIRD-PARTY-NOTICES*
-        - THIRDPARTYNOTICES*
+          - THIRD_PARTY_NOTICES*
+          - THIRD-PARTY-NOTICES*
+          - THIRDPARTYNOTICES*
         nocase: true
     policyInfo: >-
       A [`THIRD_PARTY_NOTICES.md`](https://github.com/newrelic/opensource-website/blob/develop/THIRD_PARTY_NOTICES.md)

--- a/repolinter-rulesets/new-relic-one-catalog-project.json
+++ b/repolinter-rulesets/new-relic-one-catalog-project.json
@@ -97,7 +97,7 @@
             "policyInfo": "New Relic recommends referencing the open source security policy (`https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`) in a Security section in the README. For an example of this, please see the [NR1 Catalog Template](https://github.com/newrelic/template-nerdpack#security)",
             "policyUrl": "https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code"
         },
-        "readme-contains-discuss-topic": {
+        "readme-contains-forum-topic": {
             "level": "error",
             "rule": {
                 "type": "file-contents",
@@ -105,11 +105,11 @@
                     "globsAll": ["README*"],
                     "fail-on-non-existent": true,
                     "flags": "i",
-                    "content": "discuss\\.newrelic\\.com",
-                    "human-readable-content": "a link to the appropriate discuss.newrelic.com topic"
+                    "content": "forum\\.newrelic\\.com",
+                    "human-readable-content": "a link to the appropriate forum.newrelic.com topic"
                 }
             },
-            "policyInfo": "New Relic recommends directly linking the your appropriate discuss.newrelic.com topic in the README, allowing developer an alternate method of getting support",
+            "policyInfo": "New Relic recommends directly linking the your appropriate forum.newrelic.com topic in the README, allowing developer an alternate method of getting support",
             "policyUrl": "https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code"
         },
         "third-party-notices-file-exists": {


### PR DESCRIPTION
`discuss.newrelic.com` has been moved to `forum.newrelic.com` - this PR updates the repolinter checks.