### PR TITLE
feature: disable check for security policy in Repolint configuration files

### DIFF
--- a/repolinter-rulesets/community-plus.yml
+++ b/repolinter-rulesets/community-plus.yml
@@ -70,23 +70,6 @@ rules:
       and this rule is failing, your header may be out of date, and you should
       update your header with the suggested one below
     policyUrl: https://opensource.newrelic.com/oss-category/
-  readme-contains-link-to-security-policy:
-    level: error
-    rule:
-      type: file-contents
-      options:
-        globsAll:
-          - README*
-        fail-on-non-existent: true
-        flags: i
-        content: (?:(?:https:\/\/github\.com\/newrelic\/[^\/]+)|(?:\.\.\/\.\.))\/security\/policy
-        human-readable-content: a link to the security policy for this repository
-    policyInfo: >-
-      New Relic recommends putting a link to the open source security policy for your project
-      (`https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`)
-      in the README. For an example of this, please see the "a note about vulnerabilities"
-      section of the [Open By Default repository](https://github.com/newrelic/open-by-default#contribute)
-    policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code
   readme-contains-forum-topic:
     level: error
     rule:

--- a/repolinter-rulesets/community-project.yml
+++ b/repolinter-rulesets/community-project.yml
@@ -70,23 +70,6 @@ rules:
       and this rule is failing, your header may be out of date, and you should
       update your header with the suggested one below
     policyUrl: https://opensource.newrelic.com/oss-category/
-  readme-contains-link-to-security-policy:
-    level: error
-    rule:
-      type: file-contents
-      options:
-        globsAll:
-          - README*
-        fail-on-non-existent: true
-        flags: i
-        content: (?:(?:https:\/\/github\.com\/newrelic\/[^\/]+)|(?:\.\.\/\.\.))\/security\/policy
-        human-readable-content: a link to the security policy for this repository
-    policyInfo: >-
-      New Relic recommends putting a link to the open source security policy for your project
-      (`https://github.com/newrelic/<repo-name>/security/policy` or `../../security/policy`)
-      in the README. For an example of this, please see the "a note about vulnerabilities"
-      section of the [Open By Default repository](https://github.com/newrelic/open-by-default#contribute)
-    policyUrl: https://nerdlife.datanerd.us/new-relic/security-guidelines-for-publishing-source-code
   readme-contains-forum-topic:
     level: error
     rule:


### PR DESCRIPTION
Disables  Repolinter Rulesets check for existence of a SECURITY.md link per https://github.com/newrelic/.github/issues/39

Note that this only affects Community Project and Community Plus for the moment.

Note that this will only work for repos under the newrelic org and not newrelic-experimental and other organizations, because it depends on the newrelic/.github repo.