### PR TITLE
chore: Additional valid location for THIRD_PARTY_NOTICES

### DIFF
--- a/repolinter-rulesets/community-plus.yml
+++ b/repolinter-rulesets/community-plus.yml
@@ -130,6 +130,9 @@ rules:
           - THIRD_PARTY_NOTICES*
           - THIRD-PARTY-NOTICES*
           - THIRDPARTYNOTICES*
+          - LICENSES/THIRD_PARTY_NOTICES*
+          - LICENSES/THIRD-PARTY-NOTICES*
+          - LICENSES/THIRDPARTYNOTICES*
         nocase: true
     policyInfo: >-
       A [`THIRD_PARTY_NOTICES.md`](https://github.com/newrelic/opensource-website/blob/develop/THIRD_PARTY_NOTICES.md)


### PR DESCRIPTION
Updates the `third-party-notices-exist` rule to allow the `THIRD_PARTH_NOTICES` file to exist either in root of the repo or in a `Licenses` folder. 

This is to mitigate [false-positive reports](https://github.com/newrelic/newrelic-dotnet-agent/issues/1706) when running RepoLinter on the .NET Agent repo, which maintains [`Licenses/THIRD_PARTY_NOTICES.txt`](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/licenses/THIRD_PARTY_NOTICES.txt)

