### PR TITLE
Add workflow for fossa analyze

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,25 @@
+name: FOSSA CLI Analysis
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+  workflow_dispatch:
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+    env:
+      FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+  
+      - name: Running FOSSA CLI
+        run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+          fossa --version
+          fossa analyze


### PR DESCRIPTION
This adds a workflow that will pull the latest FOSSA CLI and run `fossa analyze`  on the currently checked out branch. 
`fossa analyze` will scan the repo and submit results to app.fossa.com, without blocking a merge.
This workflow is intended to be used in an organization-side repo ruleset that will enforce its use on all repos. 