### PR TITLE
Skip FOSSA for forks

### DIFF
--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -7,7 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_env:
+    runs-on: ubuntu-latest
+    env:
+      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
+    steps:
+      - id: check-fossa-api-key
+        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
+    outputs:
+      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+
   fossa:
+    needs: check_env
+    if: ${{ needs.check_env.HAS_FOSSA_API_KEY }}
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -27,9 +27,6 @@ jobs:
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - name: Give GitHub Actions access to private crates

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -7,7 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_env:
+    runs-on: ubuntu-latest
+    env:
+      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
+    steps:
+      - id: check-fossa-api-key
+        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
+    outputs:
+      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+
   fossa:
+    needs: check_env
+    if: ${{ needs.check_env.HAS_FOSSA_API_KEY }}
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -27,9 +27,6 @@ jobs:
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - id: fossa-list-targets

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -7,7 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_env:
+    runs-on: ubuntu-latest
+    env:
+      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
+    steps:
+      - id: check-fossa-api-key
+        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
+    outputs:
+      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+
   fossa:
+    needs: check_env
+    if: ${{ needs.check_env.HAS_FOSSA_API_KEY }}
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -27,9 +27,6 @@ jobs:
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -7,7 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_env:
+    runs-on: ubuntu-latest
+    env:
+      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
+    steps:
+      - id: check-fossa-api-key
+        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
+    outputs:
+      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+
   fossa:
+    needs: check_env
+    if: ${{ needs.check_env.HAS_FOSSA_API_KEY }}
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -27,9 +27,6 @@ jobs:
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -7,7 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_env:
+    runs-on: ubuntu-latest
+    env:
+      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
+    steps:
+      - id: check-fossa-api-key
+        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
+    outputs:
+      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+
   fossa:
+    needs: check_env
+    if: ${{ needs.check_env.HAS_FOSSA_API_KEY }}
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -27,9 +27,6 @@ jobs:
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -7,7 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_env:
+    runs-on: ubuntu-latest
+    env:
+      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
+    steps:
+      - id: check-fossa-api-key
+        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
+    outputs:
+      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+
   fossa:
+    needs: check_env
+    if: ${{ needs.check_env.HAS_FOSSA_API_KEY }}
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -27,9 +27,6 @@ jobs:
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
 
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - name: Download newrelic.jar


### PR DESCRIPTION
PRs from forks do not have access to secrets on the base repository. This checks if the API token is set in the `secrets` context. If not, this means the PR is from an external repo. In this case the workflow skips the FOSSA job. 

Also delete the `strategy` key which is only used if `matrix` is defined. 