### PR TITLE
Fixes: scala for java tests, set fossaAnalyzeResult to N/A

### DIFF
--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -72,7 +72,7 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep "ERROR" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
+          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -43,15 +45,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -61,10 +64,10 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
@@ -73,10 +76,10 @@ jobs:
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -86,8 +89,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1
-

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - CAOS
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -39,15 +41,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -57,10 +60,10 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
@@ -69,10 +72,10 @@ jobs:
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -82,7 +85,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - Default
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -68,7 +68,7 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep "ERROR" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
+          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - Elixir
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -43,15 +45,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -61,22 +64,22 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALZYE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALZYE_ERR_FILE || true
+          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
           if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -86,8 +89,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1
-

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - name: Checkout this repo
@@ -62,15 +64,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -80,22 +83,22 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALZYE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALZYE_ERR_FILE || true
+          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
           if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -105,8 +108,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1
-

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - Gradle
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - Ruby
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -42,15 +44,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -60,22 +63,22 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALZYE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALZYE_ERR_FILE || true
+          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
           if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -85,8 +88,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1
-

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -44,15 +46,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -62,22 +65,22 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALZYE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALZYE_ERR_FILE || true
+          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
           if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -87,7 +90,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download newrelic.jar
-        if: ${{ github.repository == 'newrelic-csec/newrelic-java-examples' }}
+        if: ${{ github.repository == 'newrelic/newrelic-java-examples' }}
         run: |
           mkdir newrelic-java-agent/scala/segment-api-synchronous/libs
           curl https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic.jar --output newrelic-java-agent/scala/segment-api-synchronous/libs/newrelic.jar


### PR DESCRIPTION
### Fixes
- In `fossa-scala.yml`, correct the condition to check for newrelic-java-tests repo
- If fossa-list-targets does not find targets, set fossaAnalyzeResult to "N/A"
    - currently fossaAnalyzeResult has the default value of "Error" for repos without targets. Changing to "N/A" makes the data more clear. 
    - this change does not affect whether the workflow passes or fails 

### Refactors
- In all workflows, move variables for custom properties from step outputs to a job environment variable in order to simplify sharing the values across workflow steps. 
- Add descriptor to workflow name, i.e. ` FOSSA CLI Analysis - Gradle ` 
- standardize grep for error logs to be `grep -i error` (case insensitive)
  