### PR TITLE
Refactor check env and fossa cli

### DIFF
--- a/.github/composite/fossa-composite/action.yml
+++ b/.github/composite/fossa-composite/action.yml
@@ -1,0 +1,85 @@
+name: 'FOSSA Composite Action'
+description: 'Shared action for running FOSSA workflows'
+#inputs:
+#  FOSSA_API_KEY:
+#    description: 'API key for pushing results from fossa analyze'
+#    required: false
+#  ORG: 
+#    description: 'github.repository_owner'
+#    required: true
+#  REPO: 
+#    description: 'github.repository'
+#    required: true
+#  CUSTOM_PROPS_PAT:
+#    description: 'PAT for updating custom properties'
+#    required: true
+    
+
+runs:
+  using: 'composite'
+  steps: 
+    - id: fossa-list-targets
+      name: Run fossa list-targets
+      shell: bash
+      run: |
+        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+        export LIST_TARGETS_OUT_FILE=${{ runner.temp }}/list-targets_out.txt
+        export LIST_TARGETS_ERR_FILE=${{ runner.temp }}/list-targets_err.txt
+
+        fossa list-targets --format text 1>$LIST_TARGETS_OUT_FILE 2>$LIST_TARGETS_ERR_FILE || true
+
+        if grep "\[ERROR\]" $LIST_TARGETS_ERR_FILE >/dev/null 2>&1
+        then
+            echo "::error::fossa list-targets ran with errors."
+            cat $LIST_TARGETS_ERR_FILE
+            echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
+        elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
+        then
+            echo "::notice::Fossa found analysis targets."
+            cat $LIST_TARGETS_OUT_FILE
+            echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
+        else
+            echo "::warning::Fossa did not find any analysis targets."
+            echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+            echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
+        fi
+
+    - id: fossa-analyze
+      name: Run fossa analyze
+      shell: bash
+      if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
+      run: |
+        export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
+        export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+        fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
+        if grep "\[ERROR\]" $ANALYZE_ERR_FILE >/dev/null 2>&1
+        then
+            echo "::error::fossa analyze ran with errors."
+            cat $ANALYZE_ERR_FILE
+            echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
+        else
+            cat $ANALYZE_OUT_FILE
+            echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
+        fi
+
+    - name: Set custom properties 
+      shell: bash
+      run: |
+        response=$(curl --write-out '%{http_code}' --silent --output /dev/null \
+          -L \
+          -X PATCH \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/orgs/$ORG/properties/values \
+          -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}, {"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}' \
+        )
+        if [[ $response != 204 ]]
+        then
+            echo "::warning::Writing custom properties failed."
+        fi
+    - name: Exit
+      shell: bash
+      if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
+      run: |
+        exit 1

--- a/.github/composite/fossa-composite/action.yml
+++ b/.github/composite/fossa-composite/action.yml
@@ -1,20 +1,5 @@
 name: 'FOSSA Composite Action'
 description: 'Shared action for running FOSSA workflows'
-#inputs:
-#  FOSSA_API_KEY:
-#    description: 'API key for pushing results from fossa analyze'
-#    required: false
-#  ORG: 
-#    description: 'github.repository_owner'
-#    required: true
-#  REPO: 
-#    description: 'github.repository'
-#    required: true
-#  CUSTOM_PROPS_PAT:
-#    description: 'PAT for updating custom properties'
-#    required: true
-    
-
 runs:
   using: 'composite'
   steps: 

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -72,7 +72,7 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep "ERROR" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
+          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -43,15 +45,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -61,10 +64,10 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
@@ -73,10 +76,10 @@ jobs:
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -86,8 +89,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1
-

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   check_env:
     uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   fossa:
     needs: check_env

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -5,14 +5,7 @@ on:
 
 jobs:
   check_env:
-    runs-on: ubuntu-latest
-    env:
-      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
-    steps:
-      - id: check-fossa-api-key
-        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
-    outputs:
-      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
 
   fossa:
     needs: check_env
@@ -32,64 +25,5 @@ jobs:
         uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.CAOS_RUST_CRATE_FOSSA }}
-      - id: fossa-list-targets
-        name: Run fossa list-targets
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-          export LIST_TARGETS_OUT_FILE=${{ runner.temp }}/list-targets_out.txt
-          export LIST_TARGETS_ERR_FILE=${{ runner.temp }}/list-targets_err.txt
-
-          fossa list-targets --format text 1>$LIST_TARGETS_OUT_FILE 2>$LIST_TARGETS_ERR_FILE || true
-
-          if [[ $(grep -i "error" $LIST_TARGETS_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa list-targets ran with errors."
-              cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
-          elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::notice::Fossa found analysis targets."
-              cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
-          else
-              echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
-              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaHasTargets custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
-      - id: fossa-analyze
-        name: Run fossa analyze
-        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
-        run: |
-          export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa analyze ran with errors."
-              cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
-          else
-              cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaAnalyzeResult custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
-      - name: Exit
-        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
-        run: exit 1
+      - id: fossa-cli
+        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - CAOS
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-caos.yml
+++ b/.github/workflows/fossa-caos.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check_env:
-    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    uses: newrelic/.github/.github/workflows/fossa-check-env.yml@main
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
@@ -28,4 +28,4 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.CAOS_RUST_CRATE_FOSSA }}
       - id: fossa-cli
-        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable
+        uses: newrelic/.github/.github/composite/fossa-composite@main

--- a/.github/workflows/fossa-check-env.yml
+++ b/.github/workflows/fossa-check-env.yml
@@ -1,0 +1,17 @@
+name: FOSSA Check Env
+on:
+  workflow_call:
+    secrets:
+      FOSSA_API_KEY:
+       required: false
+
+jobs:
+  check_env:
+    runs-on: ubuntu-latest
+    env:
+      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
+    steps:
+      - id: check-fossa-api-key
+        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
+    outputs:
+      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}

--- a/.github/workflows/fossa-check-env.yml
+++ b/.github/workflows/fossa-check-env.yml
@@ -14,9 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
-    outputs:
-      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
     steps:
       - id: check-fossa-api-key
         run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
-
+    outputs:
+      check: ${{ steps.check-fossa-api-key.outputs.check }}

--- a/.github/workflows/fossa-check-env.yml
+++ b/.github/workflows/fossa-check-env.yml
@@ -4,14 +4,19 @@ on:
     secrets:
       FOSSA_API_KEY:
        required: false
+    outputs:
+      HAS_FOSSA_API_KEY:
+        description: "True if FOSSA API key is available."
+        value: ${{ jobs.check_env.outputs.check }}
 
 jobs:
   check_env:
     runs-on: ubuntu-latest
     env:
       HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
+    outputs:
+      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
     steps:
       - id: check-fossa-api-key
         run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
-    outputs:
-      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -39,15 +41,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -57,10 +60,10 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
@@ -69,10 +72,10 @@ jobs:
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -82,7 +85,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -68,8 +68,15 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          echo $PIPESTATUS[0]
-          echo $PIPESTATUS[1]
+          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
+          then
+              echo "::error::fossa analyze ran with errors."
+              cat $ANALYZE_ERR_FILE
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
+          else
+              cat $ANALYZE_OUT_FILE
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
+          fi
       - name: Set fossaAnalyzeResult custom property
         run: |
           curl -L \

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -6,14 +6,7 @@ on:
 
 jobs:
   check_env:
-    runs-on: ubuntu-latest
-    env:
-      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
-    steps:
-      - id: check-fossa-api-key
-        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
-    outputs:
-      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
 
   fossa:
     needs: check_env
@@ -29,64 +22,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - id: fossa-list-targets
-        name: Run fossa list-targets
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-          export LIST_TARGETS_OUT_FILE=${{ runner.temp }}/list-targets_out.txt
-          export LIST_TARGETS_ERR_FILE=${{ runner.temp }}/list-targets_err.txt
-
-          fossa list-targets --format text 1>$LIST_TARGETS_OUT_FILE 2>$LIST_TARGETS_ERR_FILE || true
-
-          if grep "\[ERROR\]" $LIST_TARGETS_ERR_FILE >/dev/null 2>&1
-          then
-              echo "::error::fossa list-targets ran with errors."
-              cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
-          elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::notice::Fossa found analysis targets."
-              cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
-          else
-              echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
-              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaHasTargets custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
-      - id: fossa-analyze
-        name: Run fossa analyze
-        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
-        run: |
-          export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if grep "\[ERROR\]" $ANALYZE_ERR_FILE >/dev/null 2>&1
-          then
-              echo "::error::fossa analyze ran with errors."
-              cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
-          else
-              cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaAnalyzeResult custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
-      - name: Exit
-        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
-        run: exit 1
+      - id: fossa-cli
+        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -68,15 +68,8 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa analyze ran with errors."
-              cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
-          else
-              cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
-          fi
+          echo $PIPESTATUS[0]
+          echo $PIPESTATUS[1]
       - name: Set fossaAnalyzeResult custom property
         run: |
           curl -L \

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -2,6 +2,7 @@ name: FOSSA CLI Analysis - Default
 on:
   pull_request:
     branches: [ $default-branch ]
+  workflow_call:
 
 jobs:
   check_env:

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -2,11 +2,12 @@ name: FOSSA CLI Analysis - Default
 on:
   pull_request:
     branches: [ $default-branch ]
-  workflow_call:
 
 jobs:
   check_env:
     uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   fossa:
     needs: check_env

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -68,7 +68,7 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if grep "[ERROR]" $ANALYZE_ERR_FILE >/dev/null 2>&1
+          if grep "\[ERROR\]" $ANALYZE_ERR_FILE >/dev/null 2>&1
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
@@ -77,9 +77,6 @@ jobs:
               cat $ANALYZE_OUT_FILE
               echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
-          curl -i -X POST https://webhook.site/ab15f1ed-156e-43c6-8cd6-98f6504cbe66 \
-            -H "Content-Type: text/plain" \
-            --data-binary "@${{ runner.temp }}/analyze_err.txt"
       - name: Set fossaAnalyzeResult custom property
         run: |
           curl -L \

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - Default
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -68,7 +68,7 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep "ERROR" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
+          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check_env:
-    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    uses: newrelic/.github/.github/workflows/fossa-check-env.yml@main
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
@@ -24,4 +24,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: fossa-cli
-        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable
+        uses: newrelic/.github/.github/composite/fossa-composite@main

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -68,7 +68,7 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
+          if grep "[ERROR]" $ANALYZE_ERR_FILE
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -77,6 +77,9 @@ jobs:
               cat $ANALYZE_OUT_FILE
               echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
+          curl -i -X POST https://webhook.site/ab15f1ed-156e-43c6-8cd6-98f6504cbe66 \
+            -H "Content-Type: text/plain" \
+            --data-binary "@${{ runner.temp }}/analyze_err.txt"
       - name: Set fossaAnalyzeResult custom property
         run: |
           curl -L \

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -68,7 +68,7 @@ jobs:
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
           export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
           fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if grep "[ERROR]" $ANALYZE_ERR_FILE
+          if grep "[ERROR]" $ANALYZE_ERR_FILE >/dev/null 2>&1
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE

--- a/.github/workflows/fossa-default.yml
+++ b/.github/workflows/fossa-default.yml
@@ -37,7 +37,7 @@ jobs:
 
           fossa list-targets --format text 1>$LIST_TARGETS_OUT_FILE 2>$LIST_TARGETS_ERR_FILE || true
 
-          if [[ $(grep -i "error" $LIST_TARGETS_ERR_FILE | wc -l) -gt 0 ]]
+          if grep "\[ERROR\]" $LIST_TARGETS_ERR_FILE >/dev/null 2>&1
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -5,14 +5,7 @@ on:
 
 jobs:
   check_env:
-    runs-on: ubuntu-latest
-    env:
-      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
-    steps:
-      - id: check-fossa-api-key
-        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
-    outputs:
-      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
 
   fossa:
     needs: check_env
@@ -32,64 +25,5 @@ jobs:
         with:
             otp-version: '26'
             elixir: '1.15'
-      - id: fossa-list-targets
-        name: Run fossa list-targets
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-          export LIST_TARGETS_OUT_FILE=${{ runner.temp }}/list-targets_out.txt
-          export LIST_TARGETS_ERR_FILE=${{ runner.temp }}/list-targets_err.txt
-
-          fossa list-targets --format text 1>$LIST_TARGETS_OUT_FILE 2>$LIST_TARGETS_ERR_FILE || true
-
-          if [[ $(grep -i "error" $LIST_TARGETS_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa list-targets ran with errors."
-              cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
-          elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::notice::Fossa found analysis targets."
-              cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
-          else
-              echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
-              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaHasTargets custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
-      - id: fossa-analyze
-        name: Run fossa analyze
-        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
-        run: |
-          export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa analyze ran with errors."
-              cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
-          else
-              cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaAnalyzeResult custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
-      - name: Exit
-        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
-        run: exit 1
+      - id: fossa-cli
+        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - Elixir
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -26,6 +26,6 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
             otp-version: '26'
-            elixir: '1.15'
+            elixir-version: '1.15'
       - id: fossa-cli
         uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   check_env:
     uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   fossa:
     needs: check_env

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -43,15 +45,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -61,22 +64,22 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALZYE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALZYE_ERR_FILE || true
+          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
           if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -86,8 +89,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1
-

--- a/.github/workflows/fossa-elixir.yml
+++ b/.github/workflows/fossa-elixir.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check_env:
-    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    uses: newrelic/.github/.github/workflows/fossa-check-env.yml@main
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
@@ -28,4 +28,4 @@ jobs:
             otp-version: '26'
             elixir-version: '1.15'
       - id: fossa-cli
-        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable
+        uses: newrelic/.github/.github/composite/fossa-composite@main

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -5,14 +5,7 @@ on:
 
 jobs:
   check_env:
-    runs-on: ubuntu-latest
-    env:
-      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
-    steps:
-      - id: check-fossa-api-key
-        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
-    outputs:
-      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
 
   fossa:
     needs: check_env
@@ -51,64 +44,5 @@ jobs:
           cache-read-only: true
       - name: Setup Gradle options
         run: echo "GRADLE_OPTIONS=--console=plain --parallel -Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JAVA_HOME_8_X64,JAVA_HOME_11_X64,JAVA_HOME_17_X64,JAVA_HOME_21_X64" >> $GITHUB_ENV
-      - id: fossa-list-targets
-        name: Run fossa list-targets
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-          export LIST_TARGETS_OUT_FILE=${{ runner.temp }}/list-targets_out.txt
-          export LIST_TARGETS_ERR_FILE=${{ runner.temp }}/list-targets_err.txt
-
-          fossa list-targets --format text 1>$LIST_TARGETS_OUT_FILE 2>$LIST_TARGETS_ERR_FILE || true
-
-          if [[ $(grep -i "error" $LIST_TARGETS_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa list-targets ran with errors."
-              cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
-          elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::notice::Fossa found analysis targets."
-              cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
-          else
-              echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
-              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaHasTargets custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
-      - id: fossa-analyze
-        name: Run fossa analyze
-        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
-        run: |
-          export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa analyze ran with errors."
-              cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
-          else
-              cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaAnalyzeResult custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
-      - name: Exit
-        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
-        run: exit 1
+      - id: fossa-cli
+        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check_env:
-    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    uses: newrelic/.github/.github/workflows/fossa-check-env.yml@main
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
@@ -47,4 +47,4 @@ jobs:
       - name: Setup Gradle options
         run: echo "GRADLE_OPTIONS=--console=plain --parallel -Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.fromEnv=JAVA_HOME_8_X64,JAVA_HOME_11_X64,JAVA_HOME_17_X64,JAVA_HOME_21_X64" >> $GITHUB_ENV
       - id: fossa-cli
-        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable
+        uses: newrelic/.github/.github/composite/fossa-composite@main

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   check_env:
     uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   fossa:
     needs: check_env

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - name: Checkout this repo
@@ -62,15 +64,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -80,22 +83,22 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALZYE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALZYE_ERR_FILE || true
+          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
           if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -105,8 +108,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1
-

--- a/.github/workflows/fossa-gradle.yml
+++ b/.github/workflows/fossa-gradle.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - Gradle
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -1,4 +1,4 @@
-name: FOSSA CLI Analysis
+name: FOSSA CLI Analysis - Ruby
 on:
   pull_request:
     branches: [ $default-branch ]

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check_env:
-    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    uses: newrelic/.github/.github/workflows/fossa-check-env.yml@main
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
@@ -27,4 +27,4 @@ jobs:
         with:
           ruby-version: '3.2'
       - id: fossa-cli
-        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable
+        uses: newrelic/.github/.github/composite/fossa-composite@main

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   check_env:
     uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   fossa_ruby:
     needs: check_env

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -4,26 +4,21 @@ on:
     branches: [ $default-branch ]
 
 jobs:
-  check_env:
+  fossa_ruby:
     runs-on: ubuntu-latest
     env:
-      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
-    steps:
-      - id: check-fossa-api-key
-        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
-    outputs:
-      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+      FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}
+      ORG: ${{ github.repository_owner }}
+      REPO: ${{ github.repository }}
+      CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
-  prep:
-    needs: check_env
-    if: ${{ needs.check_env.outputs.HAS_FOSSA_API_KEY == 'true' }}
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
-
-  fossa:
-    uses: newrelic-csec/.github/.github/workflows/fossa-default.yml@reusable
-    needs: prep
+      - id: fossa-cli
+        if: ${{ env.FOSSA_API_KEY != '' }}
+        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -42,15 +44,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -60,22 +63,22 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALZYE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALZYE_ERR_FILE || true
+          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
           if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -85,8 +88,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1
-

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -14,81 +14,16 @@ jobs:
     outputs:
       HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
 
-  fossa:
+  prep:
     needs: check_env
     if: ${{ needs.check_env.outputs.HAS_FOSSA_API_KEY == 'true' }}
     runs-on: ubuntu-latest
-    env:
-      FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}
-      ORG: ${{ github.repository_owner }}
-      REPO: ${{ github.repository }}
-      CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
-      HAS_FOSSA_TARGETS: ""
-      FOSSA_ANALYZE_RESULT: ""
-
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
-      - id: fossa-list-targets
-        name: Run fossa list-targets
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-          export LIST_TARGETS_OUT_FILE=${{ runner.temp }}/list-targets_out.txt
-          export LIST_TARGETS_ERR_FILE=${{ runner.temp }}/list-targets_err.txt
 
-          fossa list-targets --format text 1>$LIST_TARGETS_OUT_FILE 2>$LIST_TARGETS_ERR_FILE || true
-
-          if [[ $(grep -i "error" $LIST_TARGETS_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa list-targets ran with errors."
-              cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
-          elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::notice::Fossa found analysis targets."
-              cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
-          else
-              echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
-              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaHasTargets custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
-      - id: fossa-analyze
-        name: Run fossa analyze
-        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
-        run: |
-          export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa analyze ran with errors."
-              cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
-          else
-              cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaAnalyzeResult custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
-      - name: Exit
-        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
-        run: exit 1
+  fossa:
+    uses: newrelic-csec/.github/.github/workflows/fossa-default.yml@reusable
+    needs: prep

--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -4,7 +4,12 @@ on:
     branches: [ $default-branch ]
 
 jobs:
+  check_env:
+    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+
   fossa_ruby:
+    needs: check_env
+    if: ${{ needs.check_env.outputs.HAS_FOSSA_API_KEY == 'true' }}
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}
@@ -20,5 +25,4 @@ jobs:
         with:
           ruby-version: '3.2'
       - id: fossa-cli
-        if: ${{ env.FOSSA_API_KEY != '' }}
         uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -5,14 +5,7 @@ on:
 
 jobs:
   check_env:
-    runs-on: ubuntu-latest
-    env:
-      HAS_FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY != '' }}
-    steps:
-      - id: check-fossa-api-key
-        run: echo "check=$HAS_FOSSA_API_KEY" >> "$GITHUB_OUTPUT"
-    outputs:
-      HAS_FOSSA_API_KEY: ${{ steps.check-fossa-api-key.outputs.check }}
+    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
 
   fossa:
     needs: check_env
@@ -33,64 +26,5 @@ jobs:
         run: |
           mkdir newrelic-java-agent/scala/segment-api-synchronous/libs
           curl https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic.jar --output newrelic-java-agent/scala/segment-api-synchronous/libs/newrelic.jar
-      - id: fossa-list-targets
-        name: Run fossa list-targets
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-          export LIST_TARGETS_OUT_FILE=${{ runner.temp }}/list-targets_out.txt
-          export LIST_TARGETS_ERR_FILE=${{ runner.temp }}/list-targets_err.txt
-
-          fossa list-targets --format text 1>$LIST_TARGETS_OUT_FILE 2>$LIST_TARGETS_ERR_FILE || true
-
-          if [[ $(grep -i "error" $LIST_TARGETS_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa list-targets ran with errors."
-              cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
-          elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::notice::Fossa found analysis targets."
-              cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
-          else
-              echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
-              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaHasTargets custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
-      - id: fossa-analyze
-        name: Run fossa analyze
-        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
-        run: |
-          export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
-          if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
-          then
-              echo "::error::fossa analyze ran with errors."
-              cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
-          else
-              cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
-          fi
-      - name: Set fossaAnalyzeResult custom property
-        run: |
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
-      - name: Exit
-        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
-        run: exit 1
+      - id: fossa-cli
+        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download newrelic.jar
-        if: ${{ github.repository == 'newrelic/newrelic-java-examples' }}
+        if: ${{ github.repository == 'newrelic-csec/newrelic-java-examples' }}
         run: |
           mkdir newrelic-java-agent/scala/segment-api-synchronous/libs
           curl https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic.jar --output newrelic-java-agent/scala/segment-api-synchronous/libs/newrelic.jar

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check_env:
-    uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    uses: newrelic/.github/.github/workflows/fossa-check-env.yml@main
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
@@ -24,9 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download newrelic.jar
-        if: ${{ github.repository == 'newrelic-csec/newrelic-java-examples' }}
+        if: ${{ github.repository == 'newrelic/newrelic-java-examples' }}
         run: |
           mkdir newrelic-java-agent/scala/segment-api-synchronous/libs
           curl https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic.jar --output newrelic-java-agent/scala/segment-api-synchronous/libs/newrelic.jar
       - id: fossa-cli
-        uses: newrelic-csec/.github/.github/composite/fossa-composite@reusable
+        uses: newrelic/.github/.github/composite/fossa-composite@main

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   check_env:
     uses: newrelic-csec/.github/.github/workflows/fossa-check-env.yml@reusable
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   fossa:
     needs: check_env

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -23,6 +23,8 @@ jobs:
       ORG: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
       CUSTOM_PROPS_PAT: ${{ secrets.FOSSA_PAT }}
+      HAS_FOSSA_TARGETS: ""
+      FOSSA_ANALYZE_RESULT: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -44,15 +46,16 @@ jobs:
           then
               echo "::error::fossa list-targets ran with errors."
               cat $LIST_TARGETS_ERR_FILE
-              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=Error" >> "$GITHUB_ENV"
           elif [[ $(cat $LIST_TARGETS_OUT_FILE | wc -l) -gt 0 ]]
           then
               echo "::notice::Fossa found analysis targets."
               cat $LIST_TARGETS_OUT_FILE
-              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=True" >> "$GITHUB_ENV"
           else
               echo "::warning::Fossa did not find any analysis targets."
-              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_OUTPUT"
+              echo "HAS_FOSSA_TARGETS=False" >> "$GITHUB_ENV"
+              echo "FOSSA_ANALYZE_RESULT=N/A" >> "$GITHUB_ENV"
           fi
       - name: Set fossaHasTargets custom property
         run: |
@@ -62,22 +65,22 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value":"'"${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaHasTargets","value": "'"$HAS_FOSSA_TARGETS"'"}]}'
       - id: fossa-analyze
         name: Run fossa analyze
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'True'}}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'True'}}
         run: |
           export ANALYZE_OUT_FILE=${{ runner.temp }}/analyze_out.txt
-          export ANALZYE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
-          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALZYE_ERR_FILE || true
+          export ANALYZE_ERR_FILE=${{ runner.temp }}/analyze_err.txt
+          fossa analyze --team='Service Accounts' --policy='New Relic Public Github' 1>$ANALYZE_OUT_FILE 2>$ANALYZE_ERR_FILE || true
           if [[ $(grep -i "error" $ANALYZE_ERR_FILE | wc -l) -gt 0 ]]
           then
               echo "::error::fossa analyze ran with errors."
               cat $ANALYZE_ERR_FILE
-              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Error" >> "$GITHUB_ENV"
           else
               cat $ANALYZE_OUT_FILE
-              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_OUTPUT"
+              echo "FOSSA_ANALYZE_RESULT=Success" >> "$GITHUB_ENV"
           fi
       - name: Set fossaAnalyzeResult custom property
         run: |
@@ -87,7 +90,7 @@ jobs:
             -H "Authorization: Bearer $CUSTOM_PROPS_PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
-            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
+            -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value": "'"$FOSSA_ANALYZE_RESULT"'"}]}'
       - name: Exit
-        if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
+        if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download newrelic.jar
-        if: ${{ github.repository == 'newrelic-csec/newrelic-java-examples' }}
+        if: ${{ github.repository == 'newrelic/newrelic-java-examples' }}
         run: |
           mkdir newrelic-java-agent/scala/segment-api-synchronous/libs
           curl https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic.jar --output newrelic-java-agent/scala/segment-api-synchronous/libs/newrelic.jar


### PR DESCRIPTION
# Refactor check-env and FOSSA CLI
Refactor all workflows to pull out duplicate code from `check_env` and `fossa` jobs. Fix bugs that suppressed errors from FOSSA analyze, and incorrectly set the `fossaAnalyzeResult` custom property. 

### Refactors
- Pull out FOSSA CLI duplicated code into a [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) at [.github/composite/fossa-composite/action.yml](https://github.com/newrelic/.github/blob/a95054112259edb031c2147731bd054fc97e36e5/.github/composite/fossa-composite/action.yml). 
  - A composite action enables the FOSSA steps to be called in the same job as the calling job. This allows the FOSSA CLI to to run after required configuration steps such as installing package managers. 
- Pull out `check-env` duplicated code into a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) at [.github/workflows/fossa-check-env.yml](https://github.com/newrelic/.github/blob/a95054112259edb031c2147731bd054fc97e36e5/.github/workflows/fossa-check-env.yml)
    - A reusable workflow runs as a separate job. This allows it to be tracked and monitored separately from the FOSSA job. It also minimizes passing of required secrets from the caller to the `check-env` job. 

### Bugfixes
- Change error checking of fossa CLI commands to [search for `[ERROR]` in error logs](https://github.com/newrelic/.github/pull/73/files#diff-0072ff56e6b09e5400af2314f02e7614c23f49543891219ca25e8b183a901495R40) (exact match)
  - [previous check](https://github.com/newrelic/.github/pull/73/files#diff-f3fcd3e07be15dff6bf1f07b3d81cc2d4c809ebd35581788e5b05e27b33fa5eaL71) was incorrectly matching on an [informational log with the word "error" ](https://github.com/fossas/fossa-cli/blob/c43e2e362c03154d0d0cdb30e5fa80c1fd8bdda2/src/App/Fossa/Analyze/ScanSummary.hs#L166) 
  - We are resorting to text matching because we couldn't find an exit code for `fossa analyze` that indicates an execution error. Failing error codes indicate a policy violation, which we don't want to block on at this time.
- [Initialize `HAS_FOSSA_TARGETS` and `FOSSA_ANALYZE_RESULT` env variables to ""](https://github.com/newrelic/.github/pull/73/files#diff-a35a493af906a58011d7c0de44a2150c8b864af2e4a43eec58c4bdbf26ea0f3fR21-R22)
  - This ensures that the values of custom properties get set to default values if the FOSSA job encounters errors.
- fossa-elixir.yml
    - [pass`elixir-version` input variable](https://github.com/newrelic/.github/pull/73/files#diff-cd334ada13e0465707133e3e98eecea5231eb90edfffec5bb79c2d53dbc3f49bL32)
    - fix "ANALZYE" [typo](https://github.com/newrelic/.github/pull/73/files#diff-cd334ada13e0465707133e3e98eecea5231eb90edfffec5bb79c2d53dbc3f49bL71-L72) that suppressed fossa analyze errors (by replacing all FOSSA work with call to shared composite workflow)
- fossa-ruby.yml
   - fix the same ANALZYE [typo](https://github.com/newrelic/.github/pull/73/files#diff-f3fcd3e07be15dff6bf1f07b3d81cc2d4c809ebd35581788e5b05e27b33fa5eaL69-L70)
- fossa-scala.yml
  - fix the same ANALZYE [typo](https://github.com/newrelic/.github/pull/73/files#diff-68e0e55a6799914c803c39ad998789531ab2a1d4f854613185c91d6fa22ae66fL71-L72)


