### PR TITLE
Ruby workflow enhancements

### DIFF
--- a/.github/workflows/fossa-ruby-bundler.yml
+++ b/.github/workflows/fossa-ruby-bundler.yml
@@ -22,9 +22,22 @@ jobs:
       FOSSA_ANALYZE_RESULT: ""
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
+      - name: Ensure that a Gemfile.lock file exists for each Gemfile file
+        run: |
+          echo "Ensuring that Gemfile.lock files exist..."
+          for gemfile in $(find . -name Gemfile -not -path './test/**' -not -path './spec/**'); do
+            dir=${gemfile%/*}
+            echo "Found Gemfile at $dir"
+            if [[ -e "$dir/Gemfile.lock" ]]; then
+              echo "Found Gemfile.lock at $dir"
+            else
+              echo "No Gemfile.lock found at $dir - generating one..."
+              bundle lock --gemfile "$dir/Gemfile"
+            fi
+          done
       - id: fossa-cli
         uses: newrelic/.github/.github/composite/fossa-composite@main


### PR DESCRIPTION
- checkout@v3 uses a deprecated Node.js v16 runtime and should be updated to v4
- Ruby 3.3 (not 3.2) is the latest stable Ruby, so update setup-ruby to use v3.3
- We have multiple public Ruby repos that have `Gemfile.lock` intentionally ignored by Git, but FOSSA wants that file so autogenerate it running `bundle lock` where appropriate
  - Do not run `bundle lock` if a lock file already exists
  - Handle multiple `Gemfile` locations (the NR Ruby agent has 2)
  - Ignore the `test/` and `spec/` directories