### PR TITLE
FOSSA composite action exit code

### DIFF
--- a/.github/composite/fossa-composite/action.yml
+++ b/.github/composite/fossa-composite/action.yml
@@ -67,4 +67,6 @@ runs:
       shell: bash
       if: ${{ env.HAS_FOSSA_TARGETS == 'Error' || env.FOSSA_ANALYZE_RESULT == 'Error' }}
       run: |
-        exit 1
+        echo "::notice::FOSSA - please follow up internally."        
+        exit 0
+#        exit 1


### PR DESCRIPTION
The if the FOSSA CLI errors, the check shows up as a red X on all PRs, in particular PRs to public repos. We want to suppress these so that contributors and consumers do not need to worry about the checks, for the following reasons:
- scans do not address security risk
- rulesets are still in the Evaluation period
- the failing check is not the fault of external contributors.
Errors will still be logged to the job logs.