### PR TITLE
Update SECURITY.md to reference BugCrowd

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,10 @@
 # Reporting security vulnerabilities
+
 New Relic is committed to the security of our customers and your data. We believe that engaging with security researchers through our coordinated disclosure program is an important means to achieve our security goals.
 
 If you believe you have found a security vulnerability in one of our products or websites, we welcome and greatly appreciate you reporting it to New Relic through [our coordinated disclosure page on BugCrowd](https://bugcrowd.com/newrelic-mbb-og-public).
 
-Coordinated disclosure program
+## Coordinated disclosure program
 New Relic has partnered with [BugCrowd](https://bugcrowd.com/newrelic-mbb-og-public) to make it easy for researchers to report security vulnerabilities to us. In recognition of the effort involved in finding these issues, we may provide bounties for eligible reports.
 
 Please visit [our coordinated disclosure page on BugCrowd](https://bugcrowd.com/newrelic-mbb-og-public) for full details of our policies and to see previously disclosed reports.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,11 @@
 # Reporting security vulnerabilities
-
 New Relic is committed to the security of our customers and your data. We believe that engaging with security researchers through our coordinated disclosure program is an important means to achieve our security goals.
 
-If you believe you have found a security vulnerability in one of our products or websites, we welcome and greatly appreciate you reporting it to New Relic through our [coordinated disclosure page on HackerOne](https://hackerone.com/newrelic).
+If you believe you have found a security vulnerability in one of our products or websites, we welcome and greatly appreciate you reporting it to New Relic through [our coordinated disclosure page on BugCrowd](https://bugcrowd.com/newrelic-mbb-og-public).
 
-## Coordinated disclosure program
+Coordinated disclosure program
+New Relic has partnered with [BugCrowd](https://bugcrowd.com/newrelic-mbb-og-public) to make it easy for researchers to report security vulnerabilities to us. In recognition of the effort involved in finding these issues, we may provide bounties for eligible reports.
 
-New Relic has partnered with HackerOne to make it as easy as possible for researchers to report security vulnerabilities to us. In recognition of the effort involved in finding these issues, we may provide bounties for eligible reports.
+Please visit [our coordinated disclosure page on BugCrowd](https://bugcrowd.com/newrelic-mbb-og-public) for full details of our policies and to see previously disclosed reports.
 
-Please visit our [coordinated disclosure page on HackerOne](https://hackerone.com/newrelic) for full details of our policies and to see previously disclosed reports.
-
-Please ensure that you're familiar with [our policies](https://hackerone.com/newrelic) before initiating any security testing, and only test against accounts you control.
+Please ensure that you're familiar with and follow our BugCrowd policies before initiating any security testing, and only test against permitted accounts you control.


### PR DESCRIPTION
Slight edits to SECURITY.md to change references from HackerOne to BugCrowd.